### PR TITLE
Enhancement/control_scroll_behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import 'package:loop_page_view/loop_page_view.dart';
 
 A new method, 'animateJumpToPage', has been added to 'LoopPageController'. This allows it to animate a jump to any page without having to build the intervening pages, provided that 'viewportFraction' is set to 1.0.
 
-The direction to which the 'LoopPageViewController' animates can be set by updating 'LoopPageViewController.scrollDirection'. 'LoopScrollDirection.shortest' animates in the direction that requires the least amount of steps. On the other hand, 'LoopScrollDirection.forwards' always animates forwards, and 'LoopScrollDirection.backwards' always animates backwards.
+The direction to which the 'LoopPageViewController' animates can be set by updating 'LoopPageViewController.scrollBehavior'. 'LoopScrollBehavior.shortest' animates in the direction that requires the least amount of steps. On the other hand, 'LoopScrollBehavior.forwards' always animates forwards, and 'LoopScrollBehavior.backwards' always animates backwards.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Import the package into your code:
 import 'package:loop_page_view/loop_page_view.dart';
 ```
 
-It works exactly as a PageView builder constructor would, but it always requires an item count, and it requires a LoopPageController as its controller. LoopPageController also works just as a PageController would, but it correctly handles LoopPageView endless scrollable list.
+'LoopPageView' operates exactly like a 'PageView' 'builder' constructor, but it always requires an item count, as well as a 'LoopPageController' as its controller. The 'LoopPageController' functions similarly to a 'PageController', but it correctly handles the endless scrolling of 'LoopPageView'.
 
-An animateJumpToPage method was added to LoopPageController in order to animate a jump to any page without building the pages in between if viewportFraction is 1.0.
+A new method, 'animateJumpToPage', has been added to 'LoopPageController'. This allows it to animate a jump to any page without having to build the intervening pages, provided that 'viewportFraction' is set to 1.0.
+
+The direction to which the 'LoopPageViewController' animates can be set by updating 'LoopPageViewController.scrollDirection'. 'LoopScrollDirection.shortest' animates in the direction that requires the least amount of steps. On the other hand, 'LoopScrollDirection.forwards' always animates forwards, and 'LoopScrollDirection.backwards' always animates backwards.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Import the package into your code:
 import 'package:loop_page_view/loop_page_view.dart';
 ```
 
-'LoopPageView' operates exactly like a 'PageView' 'builder' constructor, but it always requires an item count, as well as a 'LoopPageController' as its controller. The 'LoopPageController' functions similarly to a 'PageController', but it correctly handles the endless scrolling of 'LoopPageView'.
+`LoopPageView` operates exactly like a `PageView` `builder` constructor, but it always requires an item count, as well as a `LoopPageController` as its controller. The `LoopPageController` functions similarly to a `PageController`, but it correctly handles the endless scrolling of `LoopPageView`.
 
-A new method, 'animateJumpToPage', has been added to 'LoopPageController'. This allows it to animate a jump to any page without having to build the intervening pages, provided that 'viewportFraction' is set to 1.0.
+A new method, `animateJumpToPage`, has been added to `LoopPageController`. This allows it to animate a jump to any page without having to build the intervening pages, provided that `viewportFraction` is set to 1.0.
 
-The direction to which the 'LoopPageViewController' animates can be set by updating 'LoopPageViewController.scrollMode'. 'LoopScrollMode.shortest' animates in the direction that requires the least amount of steps. On the other hand, 'LoopScrollMode.forwards' always animates forwards, and 'LoopScrollMode.backwards' always animates backwards.
+The direction to which the `LoopPageViewController` animates can be set by updating `LoopPageViewController.scrollMode`. `LoopScrollMode.shortest` animates in the direction that requires the least amount of steps. On the other hand, `LoopScrollMode.forwards` always animates forwards, and `LoopScrollMode.backwards` always animates backwards.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import 'package:loop_page_view/loop_page_view.dart';
 
 A new method, 'animateJumpToPage', has been added to 'LoopPageController'. This allows it to animate a jump to any page without having to build the intervening pages, provided that 'viewportFraction' is set to 1.0.
 
-The direction to which the 'LoopPageViewController' animates can be set by updating 'LoopPageViewController.scrollBehavior'. 'LoopScrollBehavior.shortest' animates in the direction that requires the least amount of steps. On the other hand, 'LoopScrollBehavior.forwards' always animates forwards, and 'LoopScrollBehavior.backwards' always animates backwards.
+The direction to which the 'LoopPageViewController' animates can be set by updating 'LoopPageViewController.scrollMode'. 'LoopScrollMode.shortest' animates in the direction that requires the least amount of steps. On the other hand, 'LoopScrollMode.forwards' always animates forwards, and 'LoopScrollMode.backwards' always animates backwards.
 
 ## Installation
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -24,7 +24,9 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final List<bool> isSelected =
       colors.map((e) => e == colors.last ? true : false).toList();
-  final LoopPageController controller = LoopPageController();
+  LoopScrollDirection selectedScrollDirection = LoopScrollDirection.shortest;
+  final LoopPageController controller =
+      LoopPageController(scrollDirection: LoopScrollDirection.shortest);
 
   @override
   Widget build(BuildContext context) {
@@ -41,6 +43,8 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              Text(
+                  "Animate direction is set to ${selectedScrollDirection.toString().split('.').last}"),
               SizedBox(
                 height: 80,
                 child: LoopPageView.builder(
@@ -96,6 +100,34 @@ class _MyAppState extends State<MyApp> {
                   controller.animateJumpToPage(selectedIndex,
                       duration: Duration(milliseconds: 400),
                       curve: Curves.easeIn);
+                },
+              ),
+              ElevatedButton(
+                child: Text("Change direction to ${(() {
+                  switch (selectedScrollDirection) {
+                    case LoopScrollDirection.shortest:
+                      return 'forwards';
+                    case LoopScrollDirection.forwards:
+                      return 'backwards';
+                    case LoopScrollDirection.backwards:
+                      return 'shortest';
+                  }
+                })()}"),
+                onPressed: () {
+                  setState(() {
+                    switch (selectedScrollDirection) {
+                      case LoopScrollDirection.shortest:
+                        selectedScrollDirection = LoopScrollDirection.forwards;
+                        break;
+                      case LoopScrollDirection.forwards:
+                        selectedScrollDirection = LoopScrollDirection.backwards;
+                        break;
+                      case LoopScrollDirection.backwards:
+                        selectedScrollDirection = LoopScrollDirection.shortest;
+                        break;
+                    }
+                    controller.scrollDirection = selectedScrollDirection;
+                  });
                 },
               ),
             ],

--- a/example/example.dart
+++ b/example/example.dart
@@ -24,9 +24,9 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final List<bool> isSelected =
       colors.map((e) => e == colors.last ? true : false).toList();
-  LoopScrollDirection selectedScrollDirection = LoopScrollDirection.shortest;
+  LoopScrollBehavior selectedScrollBehavior = LoopScrollBehavior.shortest;
   final LoopPageController controller =
-      LoopPageController(scrollDirection: LoopScrollDirection.shortest);
+      LoopPageController(scrollBehavior: LoopScrollBehavior.shortest);
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +44,7 @@ class _MyAppState extends State<MyApp> {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                  "Animate direction is set to ${selectedScrollDirection.toString().split('.').last}"),
+                  "Animate behavior is set to ${selectedScrollBehavior.toString().split('.').last}"),
               SizedBox(
                 height: 80,
                 child: LoopPageView.builder(
@@ -103,30 +103,30 @@ class _MyAppState extends State<MyApp> {
                 },
               ),
               ElevatedButton(
-                child: Text("Change direction to ${(() {
-                  switch (selectedScrollDirection) {
-                    case LoopScrollDirection.shortest:
+                child: Text("Change behavior to ${(() {
+                  switch (selectedScrollBehavior) {
+                    case LoopScrollBehavior.shortest:
                       return 'forwards';
-                    case LoopScrollDirection.forwards:
+                    case LoopScrollBehavior.forwards:
                       return 'backwards';
-                    case LoopScrollDirection.backwards:
+                    case LoopScrollBehavior.backwards:
                       return 'shortest';
                   }
                 })()}"),
                 onPressed: () {
                   setState(() {
-                    switch (selectedScrollDirection) {
-                      case LoopScrollDirection.shortest:
-                        selectedScrollDirection = LoopScrollDirection.forwards;
+                    switch (selectedScrollBehavior) {
+                      case LoopScrollBehavior.shortest:
+                        selectedScrollBehavior = LoopScrollBehavior.forwards;
                         break;
-                      case LoopScrollDirection.forwards:
-                        selectedScrollDirection = LoopScrollDirection.backwards;
+                      case LoopScrollBehavior.forwards:
+                        selectedScrollBehavior = LoopScrollBehavior.backwards;
                         break;
-                      case LoopScrollDirection.backwards:
-                        selectedScrollDirection = LoopScrollDirection.shortest;
+                      case LoopScrollBehavior.backwards:
+                        selectedScrollBehavior = LoopScrollBehavior.shortest;
                         break;
                     }
-                    controller.scrollDirection = selectedScrollDirection;
+                    controller.scrollBehavior = selectedScrollBehavior;
                   });
                 },
               ),

--- a/example/example.dart
+++ b/example/example.dart
@@ -24,9 +24,9 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final List<bool> isSelected =
       colors.map((e) => e == colors.last ? true : false).toList();
-  LoopScrollBehavior selectedScrollBehavior = LoopScrollBehavior.shortest;
+  LoopScrollMode selectedScrollMode = LoopScrollMode.shortest;
   final LoopPageController controller =
-      LoopPageController(scrollBehavior: LoopScrollBehavior.shortest);
+      LoopPageController(scrollMode: LoopScrollMode.shortest);
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +44,7 @@ class _MyAppState extends State<MyApp> {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                  "Animate behavior is set to ${selectedScrollBehavior.toString().split('.').last}"),
+                  "Animate mode is set to ${selectedScrollMode.toString().split('.').last}"),
               SizedBox(
                 height: 80,
                 child: LoopPageView.builder(
@@ -103,30 +103,30 @@ class _MyAppState extends State<MyApp> {
                 },
               ),
               ElevatedButton(
-                child: Text("Change behavior to ${(() {
-                  switch (selectedScrollBehavior) {
-                    case LoopScrollBehavior.shortest:
+                child: Text("Change mode to ${(() {
+                  switch (selectedScrollMode) {
+                    case LoopScrollMode.shortest:
                       return 'forwards';
-                    case LoopScrollBehavior.forwards:
+                    case LoopScrollMode.forwards:
                       return 'backwards';
-                    case LoopScrollBehavior.backwards:
+                    case LoopScrollMode.backwards:
                       return 'shortest';
                   }
                 })()}"),
                 onPressed: () {
                   setState(() {
-                    switch (selectedScrollBehavior) {
-                      case LoopScrollBehavior.shortest:
-                        selectedScrollBehavior = LoopScrollBehavior.forwards;
+                    switch (selectedScrollMode) {
+                      case LoopScrollMode.shortest:
+                        selectedScrollMode = LoopScrollMode.forwards;
                         break;
-                      case LoopScrollBehavior.forwards:
-                        selectedScrollBehavior = LoopScrollBehavior.backwards;
+                      case LoopScrollMode.forwards:
+                        selectedScrollMode = LoopScrollMode.backwards;
                         break;
-                      case LoopScrollBehavior.backwards:
-                        selectedScrollBehavior = LoopScrollBehavior.shortest;
+                      case LoopScrollMode.backwards:
+                        selectedScrollMode = LoopScrollMode.shortest;
                         break;
                     }
-                    controller.scrollBehavior = selectedScrollBehavior;
+                    controller.scrollMode = selectedScrollMode;
                   });
                 },
               ),

--- a/lib/loop_page_controller.dart
+++ b/lib/loop_page_controller.dart
@@ -21,19 +21,19 @@ class LoopPageController implements Listenable {
 
   int _isAnimatingJumpToPageIndex = 0;
 
-  LoopScrollDirection scrollDirection;
+  LoopScrollBehavior scrollBehavior;
 
   LoopPageController(
       {int initialPage = 0,
       bool keepPage = true,
       double viewportFraction = 1.0,
-      LoopScrollDirection scrollDirection = LoopScrollDirection.shortest})
+      LoopScrollBehavior scrollBehavior = LoopScrollBehavior.shortest})
       : assert(viewportFraction > 0.0),
         _currentShiftedPage = _initialShiftedPage,
         _itemCount = 0,
         _initialIndexShift = 0,
         initialPage = initialPage,
-        scrollDirection = scrollDirection,
+        scrollBehavior = scrollBehavior,
         _pageController = PageController(
           initialPage: initialPage + _initialShiftedPage,
           keepPage: keepPage,
@@ -232,16 +232,16 @@ class LoopPageController implements Listenable {
             ? 0
             : distance + _itemCount;
 
-    switch (scrollDirection) {
-      case LoopScrollDirection.shortest:
+    switch (scrollBehavior) {
+      case LoopScrollBehavior.shortest:
         return distance.abs() <= oppositeDistance.abs()
             ? instantCurrentShiftedPage + distance
             : instantCurrentShiftedPage + oppositeDistance;
-      case LoopScrollDirection.forwards:
+      case LoopScrollBehavior.forwards:
         return distance > oppositeDistance
             ? instantCurrentShiftedPage + distance
             : instantCurrentShiftedPage + oppositeDistance;
-      case LoopScrollDirection.backwards:
+      case LoopScrollBehavior.backwards:
         return distance < oppositeDistance
             ? instantCurrentShiftedPage + distance
             : instantCurrentShiftedPage + oppositeDistance;
@@ -267,7 +267,7 @@ class LoopPageController implements Listenable {
 /// * `shortest`: The LoopPageController will animate to the closest page. For example, if the current page is 1 and the target page is 5, but the total number of pages is 6, the LoopPageController will go backwards (from 1 to 6 to 5) instead of forwards (from 1 to 2 to 3 to 4 to 5). This is because the shortest path from 1 to 5 in this case is to go backwards.
 /// * `forwards`: The LoopPageController will always animate forwards to reach the target page. Even if the target page is technically closer when moving backwards, this option will make the controller move forwards until it reaches the target page.
 /// * `backwards`: The LoopPageController will always animate backwards to reach the target page. Similar to `forwards`, but in the opposite direction. Even if the target page is technically closer when moving forwards, this option will make the controller move backwards until it reaches the target page.
-enum LoopScrollDirection {
+enum LoopScrollBehavior {
   shortest,
   forwards,
   backwards,

--- a/lib/loop_page_controller.dart
+++ b/lib/loop_page_controller.dart
@@ -21,19 +21,19 @@ class LoopPageController implements Listenable {
 
   int _isAnimatingJumpToPageIndex = 0;
 
-  LoopScrollBehavior scrollBehavior;
+  LoopScrollMode scrollMode;
 
   LoopPageController(
       {int initialPage = 0,
       bool keepPage = true,
       double viewportFraction = 1.0,
-      LoopScrollBehavior scrollBehavior = LoopScrollBehavior.shortest})
+      LoopScrollMode scrollMode = LoopScrollMode.shortest})
       : assert(viewportFraction > 0.0),
         _currentShiftedPage = _initialShiftedPage,
         _itemCount = 0,
         _initialIndexShift = 0,
         initialPage = initialPage,
-        scrollBehavior = scrollBehavior,
+        scrollMode = scrollMode,
         _pageController = PageController(
           initialPage: initialPage + _initialShiftedPage,
           keepPage: keepPage,
@@ -232,16 +232,16 @@ class LoopPageController implements Listenable {
             ? 0
             : distance + _itemCount;
 
-    switch (scrollBehavior) {
-      case LoopScrollBehavior.shortest:
+    switch (scrollMode) {
+      case LoopScrollMode.shortest:
         return distance.abs() <= oppositeDistance.abs()
             ? instantCurrentShiftedPage + distance
             : instantCurrentShiftedPage + oppositeDistance;
-      case LoopScrollBehavior.forwards:
+      case LoopScrollMode.forwards:
         return distance > oppositeDistance
             ? instantCurrentShiftedPage + distance
             : instantCurrentShiftedPage + oppositeDistance;
-      case LoopScrollBehavior.backwards:
+      case LoopScrollMode.backwards:
         return distance < oppositeDistance
             ? instantCurrentShiftedPage + distance
             : instantCurrentShiftedPage + oppositeDistance;
@@ -267,7 +267,7 @@ class LoopPageController implements Listenable {
 /// * `shortest`: The LoopPageController will animate to the closest page. For example, if the current page is 1 and the target page is 5, but the total number of pages is 6, the LoopPageController will go backwards (from 1 to 6 to 5) instead of forwards (from 1 to 2 to 3 to 4 to 5). This is because the shortest path from 1 to 5 in this case is to go backwards.
 /// * `forwards`: The LoopPageController will always animate forwards to reach the target page. Even if the target page is technically closer when moving backwards, this option will make the controller move forwards until it reaches the target page.
 /// * `backwards`: The LoopPageController will always animate backwards to reach the target page. Similar to `forwards`, but in the opposite direction. Even if the target page is technically closer when moving forwards, this option will make the controller move backwards until it reaches the target page.
-enum LoopScrollBehavior {
+enum LoopScrollMode {
   shortest,
   forwards,
   backwards,

--- a/test/loop_page_view_test.dart
+++ b/test/loop_page_view_test.dart
@@ -5,6 +5,49 @@ import 'package:loop_page_view/loop_page_view.dart';
 Widget makeTestable(Widget widget) => MaterialApp(home: widget);
 
 void main() {
+  testWidgets('ItemCount 1', (WidgetTester tester) async {
+    final LoopPageController controller = LoopPageController(initialPage: 0);
+
+    await tester.pumpWidget(
+      makeTestable(
+        LoopPageView.builder(
+          controller: controller,
+          itemCount: 1,
+          itemBuilder: (_, index) {
+            return SizedBox(
+              child: Text('$index'),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('0'), findsOneWidget);
+    controller.jumpToPage(1);
+    await tester.pumpAndSettle();
+    expect(find.text('0'), findsOneWidget);
+  });
+
+  testWidgets('ItemCount 5 initialPage 5', (WidgetTester tester) async {
+    final LoopPageController controller = LoopPageController(initialPage: 5);
+
+    await tester.pumpWidget(
+      makeTestable(
+        LoopPageView.builder(
+          controller: controller,
+          itemCount: 5,
+          itemBuilder: (_, index) {
+            return SizedBox(
+              child: Text('$index'),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('0'), findsOneWidget);
+  });
+
   testWidgets('ItemCount 5 initialPage 1', (WidgetTester tester) async {
     final LoopPageController controller = LoopPageController(initialPage: 1);
 


### PR DESCRIPTION
* This PR adds a new `enum` called `LoopScrollMode` to give users control over the scrolling direction in `LoopPageController`. The options are shortest, forwards, and backwards. The shortest option enables the controller to choose the shortest path to the target page. The forwards and backwards options enforce a specific scrolling direction, regardless of which is the shortest path to the target page.